### PR TITLE
WICKET-6963 Use enum instead of boolean for selecting markup strategies

### DIFF
--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/border/BorderPanel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/border/BorderPanel.java
@@ -92,7 +92,7 @@ public abstract class BorderPanel extends Panel
 	@Override
 	protected IMarkupSourcingStrategy newMarkupSourcingStrategy()
 	{
-		return PanelMarkupSourcingStrategy.get(true);
+		return PanelMarkupSourcingStrategy.getInstance(PanelMarkupSourcingStrategy.PanelType.BORDER);
 	}
 
 	/**

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/form/FormComponentPanel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/form/FormComponentPanel.java
@@ -146,7 +146,7 @@ public abstract class FormComponentPanel<T> extends FormComponent<T> implements 
 	@Override
 	protected IMarkupSourcingStrategy newMarkupSourcingStrategy()
 	{
-		return PanelMarkupSourcingStrategy.get(false);
+		return PanelMarkupSourcingStrategy.getInstance(PanelMarkupSourcingStrategy.PanelType.PANEL);
 	}
 
 	@Override

--- a/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/Panel.java
+++ b/wicket-core/src/main/java/org/apache/wicket/markup/html/panel/Panel.java
@@ -81,7 +81,7 @@ public abstract class Panel extends WebMarkupContainer implements IQueueRegion
 	@Override
 	protected IMarkupSourcingStrategy newMarkupSourcingStrategy()
 	{
-		return PanelMarkupSourcingStrategy.get(false);
+		return PanelMarkupSourcingStrategy.getInstance(PanelMarkupSourcingStrategy.PanelType.PANEL);
 	}
 	
 	/**

--- a/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/HeaderSectionMyLabel.java
+++ b/wicket-core/src/test/java/org/apache/wicket/markup/parser/filter/HeaderSectionMyLabel.java
@@ -59,7 +59,7 @@ public class HeaderSectionMyLabel extends WebMarkupContainer
 	@Override
 	protected IMarkupSourcingStrategy newMarkupSourcingStrategy()
 	{
-		return new PanelMarkupSourcingStrategy(false)
+		return new PanelMarkupSourcingStrategy(PanelMarkupSourcingStrategy.PanelType.PANEL)
 		{
 			@Override
 			public IMarkupFragment getMarkup(final MarkupContainer parent, final Component child)


### PR DESCRIPTION
Builds on https://github.com/apache/wicket/pull/517 and replaces the boolean parameter with an enum.